### PR TITLE
Do not input in db if the version already exists

### DIFF
--- a/updates/07_fix-exim-and-update-version.update
+++ b/updates/07_fix-exim-and-update-version.update
@@ -16,4 +16,7 @@ ${SRCDIR}/etc/init.d/mailcleaner start
 
 # Update version and patch level
 echo "2018.03" > ${SRCDIR}/etc/mailcleaner/version.def
-echo "insert into update_patch (id, date, time, status, description) values ( 2018032201, '2018-03-22', '12:00:00', 'OK', '2018.03 migrated to Jessie' )" | ${SRCDIR}/bin/mc_mysql -s mc_config
+version_id=2018032201
+if [[ ! $(echo "select id from update_patch where id=$version_id" | ${SRCDIR}/bin/mc_mysql -m mc_config) ]]; then
+echo "insert into update_patch (id, date, time, status, description) values ( $version_id, '2018-03-22', '12:00:00', 'OK', '2018.03 migrated to Jessie' )" | ${SRCDIR}/bin/mc_mysql -m mc_config
+fi

--- a/updates/07_fix-exim-and-update-version.update
+++ b/updates/07_fix-exim-and-update-version.update
@@ -17,6 +17,6 @@ ${SRCDIR}/etc/init.d/mailcleaner start
 # Update version and patch level
 echo "2018.03" > ${SRCDIR}/etc/mailcleaner/version.def
 version_id=2018032201
-if [[ ! $(echo "select id from update_patch where id=$version_id" | ${SRCDIR}/bin/mc_mysql -m mc_config) ]]; then
-echo "insert into update_patch (id, date, time, status, description) values ( $version_id, '2018-03-22', '12:00:00', 'OK', '2018.03 migrated to Jessie' )" | ${SRCDIR}/bin/mc_mysql -m mc_config
+if [[ ($ISMASTER == "Y" || $ISMASTER == "y") && ! $(echo "select id from update_patch where id=$version_id" | ${SRCDIR}/bin/mc_mysql -s mc_config) ]]; then
+echo "insert into update_patch (id, date, time, status, description) values ( $version_id, '2018-03-22', '12:00:00', 'OK', '2018.03 migrated to Jessie' )" | ${SRCDIR}/bin/mc_mysql -s mc_config
 fi


### PR DESCRIPTION
On machines that took an upgrade with this number before, this upgrade
would return a non-zero value, and not write the flag file.
Thus, before inserting into db, we check that the version number
exists.
At this point, if the number exists, it means the machine was already
updated. If not, it just was from the script