### PR TITLE
Modify the wwlists table unicity key

### DIFF
--- a/updates/09_unique-wwlist-key.update
+++ b/updates/09_unique-wwlist-key.update
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Altering tables"
+cat << EOF | ${SRCDIR}/bin/mc_mysql -m mc_config
+ALTER TABLE wwlists DROP INDEX sender;
+ALTER TABLE wwlists ADD CONSTRAINT sender UNIQUE (sender,recipient,type);
+EOF
+table_structure=$(echo "SHOW CREATE TABLE wwlists" | ${SRCDIR}/bin/mc_mysql -m mc_config)
+if [[ -z $(echo "${table_structure}" | grep -o -e "(\`sender\`,\`recipient\`,\`type\`)") ]]; then
+    echo "There was an issue during the tables update, please run the updates again"
+    exit 1
+fi
+


### PR DESCRIPTION
Allows to have a whitelist and newslist at the same time
The lists are now checked in the order :
`blacklist -> whitelist -> newslist -> warnlist`