### PR TITLE
Change the language column size

### DIFF
--- a/libs/check_db_schema.lib
+++ b/libs/check_db_schema.lib
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+function check_db_schema {
+    table=$1
+    field=$2
+    value=$3
+
+    table_schema=$(echo "DESC ${table};" | ${SRCDIR}/bin/mc_mysql -m mc_config)
+    field_line=$(echo "${table_schema}" | grep -e "${field}")
+    value_check=$(echo "${field_line}" | grep -i -e "${value}")
+    if [[ -z "${value_check}" ]]; then
+        echo "There was an issue during the tables update, please contact your support"
+    fi
+}

--- a/updates/10_userpref_lang_size.update
+++ b/updates/10_userpref_lang_size.update
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo "Setting the length of the lang field in User preferences"
+column_length=10
+cat << EOF | ${SRCDIR}/bin/mc_mysql -m mc_config
+ALTER TABLE user_pref MODIFY COLUMN language VARCHAR(${column_length}) NOT NULL;
+ALTER TABLE domain_pref MODIFY COLUMN language VARCHAR(${column_length}) NOT NULL;
+EOF
+
+check_db_schema user_pref language "varchar(${column_length})"
+check_db_schema domain_pref language "varchar(${column_length})"


### PR DESCRIPTION
During the migration to the new language system, it was noticed that the
language field in the database, in `user_pref` and `domain_pref` was not
long enough for the ISO language codes.
This update increases the languages field to 10 characters.
Also adding a library to check that the fields are actually added to the
database properly.