### PR TITLE
Hide elements that are disarmed by MailScanner

### DIFF
--- a/updates/55_Hide_MailScanner_Disarmed.update
+++ b/updates/55_Hide_MailScanner_Disarmed.update
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export PATH="/usr/mailcleaner/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+sed -ri 's/<MailScanner(Form|Script|Object|IFrame)\$\$/<MailScanner\1\$\$ style=\\"display: none;\\"/g' /opt/MailScanner/lib/MailScanner/Message.pm*
+set_version 2021 02 09 "MailScanner hide disarmed"


### PR DESCRIPTION
Most should not appear anyways, since they are not valid tags. However it appears content of tags in the <head> will be printed as plain text. Adds 'display: none;' style to these.