### PR TITLE
Upgrade to Exim 4.94.2

### DIFF
--- a/updates/62_mc_exim_4.94.update
+++ b/updates/62_mc_exim_4.94.update
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+SHELL=$_
+FORCE=$1
+
+if [[ $SHELL != '/bin/bash' ]] && [[ $SHELL != $0 ]]; then
+	SOURCED=1
+else
+	SOURCED=0
+fi
+
+export PATH=$PATH:/usr/local/sbin:/usr/sbin:/sbin
+export DEBIAN_FRONTEND=noninteractive
+
+if [[ "$SOURCED" == 0 ]] && [[ "$FORCE" != "--force" ]]; then
+	echo "This script should be run with /root/Updater4MC/updater4mc.sh"
+	echo "If that fails and requires manual installation then be sure to run this script with the '--force' argument"
+	exit
+fi
+
+echo "Upgrading mc-exim package to 4.94.2"
+
+VERSION=`/opt/exim4/bin/exim --version 2> /dev/null | grep "Exim version 4" | sed -r 's/.*4\.([0-9][0-9]).*/\1/'`
+
+if (( "$VERSION" >= "94" )); then
+	echo "Exim already at or above 4.94"
+	if [[ "$SOURCED" == 1 ]]; then
+		set_version 2021 05 12 "Exim 4.94.2"
+        	return 0
+	else
+		exit
+	fi
+fi
+
+if [ ! -e "/usr/mailcleaner/etc/exim/exim_stage1.conf_template_4.94" ] || [ ! -e "/usr/mailcleaner/etc/exim/exim_stage4.conf_template" ] || [ ! -e "/usr/mailcleaner/etc/exim/stage1/ldap_callout_template" ]; then
+	echo "New configuration templates have not been installed. It is not safe to update Exim. Please ensure that the Git tree at /usr/mailcleaner is up-to-date with origin:master."
+	if [[ $SOURCED == 0 ]]; then
+		echo "Try running an automatic update: /root/Updater4MC/updater4mc.sh"
+		exit
+	else
+		return 1
+	fi
+fi
+
+MODIFIED=""
+if [[ "`md5sum /usr/mailcleaner/etc/exim/exim_stage1.conf_template | cut -d' ' -f1`" != "6a1b2882e874886163be36b514b7ead2" ]]; then
+	MODIFIED="/usr/mailcleaner/etc/exim/exim_stage1.conf_template"
+fi 
+if [ "`md5sum /usr/mailcleaner/etc/exim/exim_stage4.conf_template | cut -d' ' -f1`" != "a7984a4b079aa1a322d8a44b453cc7da" ]; then
+	MODIFIED="$MODIFIED
+/usr/mailcleaner/etc/exim/exim_stage4.conf_template"
+fi 
+if [ "`md5sum /usr/mailcleaner/etc/exim/stage1/ldap_callout_template | cut -d' ' -f1`" != "3e1a637c7ce0b2401a99744156b7d2aa" ]; then
+	MODIFIED="$MODIFIED
+/usr/mailcleaner/etc/exim/stage1/ldap_callout_template"
+fi 
+
+if [[ $MODIFIED != '' ]] && [[ $FORCE != '--force' ]]; then
+	cat << EOF
+ATTENTION: Cannot install Exim 4.94.2
+
+Your existing exim configuration template{s):
+
+$MODIFIED
+
+contain modifications.
+
+The modifications will not be carried over to the new template files automatically.
+
+Please port your modifications to version of each of these files ending in '_4.94' or confirm that you are okay abandoning these modifications.
+
+Once you are statisfied with the state of the '_4.94' templates run the following to force this update:
+
+  bash /root/Updater4MC/updates/62_mc_exim_4.94.update --force
+EOF
+	return 1
+	exit
+fi
+
+apt-get update
+apt-get --force-yes -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confmiss" install mc-exim=4.94.2
+
+VERSION=`/opt/exim4/bin/exim --version 2> /dev/null | grep "Exim version 4" | sed -r 's/.*4\.([0-9][0-9]).*/\1/'`
+
+if [[ $SOURCED == 0 ]]; then
+	if (( "$VERSION" >= "94" )); then
+		echo "Upgrading and restarting MailCleaner\n"
+        	/root/Updater4MC/updater4mc.sh
+	else
+		echo "Failed to install Exim 4.94.2"
+		exit
+	fi
+else
+	if (( "$VERSION" >= "94" )); then
+		return 0
+	else
+		echo "Failed to install Exim 4.94.2"
+		return 1
+	fi
+fi


### PR DESCRIPTION
Script should provide smooth upgrade as soon as the new package becomes available.

Safely prevents upgrade if main Git tree is out-of-date (missing new templates).

Safely prevents upgrade if the old templates are dirty since these changes will not be replicated.

Allows for installation to be forced when script is manually run with '--force' after the previous warning is accounted for.

Will run repeatedly until new package is successfully installed.