### PR TITLE
Add a 'content_fored' column to maillog

### DIFF
--- a/updates/64_content_checkmark.update
+++ b/updates/64_content_checkmark.update
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export PATH="/usr/mailcleaner/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+echo "Adding a 'forced' column to maillog"
+cat << EOF | mc_mysql -s mc_stats
+ALTER TABLE maillog ADD content_forced enum('1','0') NOT NULL DEFAULT '0'
+EOF
+
+set_version 2021 07 07 "Content Quarantine checkmarks"


### PR DESCRIPTION
Required to support checkmarks for already released items