### PR TITLE
Move Pyenv to tracked file, fix F2B

### DIFF
--- a/updates/65_pyenv_fix.update
+++ b/updates/65_pyenv_fix.update
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+export PATH="/usr/mailcleaner/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+SRCDIR=$(grep 'SRCDIR' /etc/mailcleaner.conf | cut -d ' ' -f3)
+if [ "$SRCDIR" = "" ]; then
+  SRCDIR=/usr/mailcleaner
+fi
+
+echo "Creating backup of /root/.bashrc as /root/.bashrc.bk"
+echo "# This backup has been created before update 65. The contents of the original will be modified to remove mailcleaner configurations that now appear in $SRCDIR/.bashrc" > /root/.bashrc.bk
+cat /root/.bashrc >> /root/.bashrc.bk
+
+for file in .bashrc .bash_profile; do
+
+    echo "Removing Pyenv setup from /root/${file}"
+    sed -i -z 's/export PYENV_ROOT="\/var\/mailcleaner\/.pyenv"\
+export PATH="$PYENV_ROOT\/bin:$PATH"\
+if command -v pyenv 1>\/dev\/null 2>&1; then\
+  eval "$(pyenv init -)"\
+fi//g' /root/${file}
+
+    if grep -Fq ". \${SRCDIR}/.bashrc" /root/${file}; then
+        echo "Already sourcing \${SRCDIR}/.bashrc in /root/${file}"
+    else
+    	echo "Sourcing \${SRCDIR}/.bashrc in /root/${file}"
+    	echo ". \${SRCDIR}/.bashrc" >> /root/${file}
+    fi
+
+done
+
+. /root/.bashrc
+
+if [[ ! -f `which fail2ban.py` ]]; then
+    echo "fail2ban.py not found. Re-installing..."
+    echo "Installing dependencies..."
+    apt-get update && sudo apt-get install --force-yes -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confmiss" aria2 git wget curl xz-utils \
+        make build-essential llvm libssl-dev zlib1g-dev libbz2-dev libreadline-dev \
+        libsqlite3-dev libncurses5-dev libncursesw5-dev tk-dev libffi-dev liblzma-dev \
+        python3-pip
+
+    echo "Installing pyenv..."
+    chown mailcleaner:mailcleaner /usr/mailcleaner/install/install_pyenv_3-7-7.sh
+    sudo -u mailcleaner /usr/mailcleaner/install/install_pyenv_3-7-7.sh
+
+    echo "Backing up etc/init.d/fail2ban"
+    cp ${SRCDIR}/etc/init.d/fail2ban ${SRCDIR}/etc/init.d/fail2ban.bk
+
+    echo "Removing distribution version of Fail2Ban..."
+    apt-get update && apt-get purge  --force-yes -y fail2ban && apt-get install --force-yes -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confmiss" fail2ban
+
+    echo "Creating expected log files..."
+    if [ ! -d "/var/mailcleaner/flags/fail2ban" ]; then
+        mkdir /var/mailcleaner/flags/fail2ban
+        touch /var/mailcleaner/flags/fail2ban/empty_file
+    fi 
+    if [ ! -f "/var/mailcleaner/log/exim_stage1/rejectlog" ]; then
+        touch /var/mailcleaner/log/exim_stage1/rejectlog
+        chown mailcleaner:mailcleaner /var/mailcleaner/log/exim_stage1/rejectlog
+        chmod 640 /var/mailcleaner/log/exim_stage1/rejectlog
+    fi
+    if [ ! -f "/var/mailcleaner/log/apache/mc_auth.log" ]; then
+        touch /var/mailcleaner/log/apache/mc_auth.log
+        chown mailcleaner:mailcleaner /var/mailcleaner/log/apache/mc_auth.log
+        chmod 644 /var/mailcleaner/log/apache/mc_auth.log
+    fi
+
+    echo "Installing cronjob..."
+    if ! crontab -l |grep "fail2ban.py cron-job"; then
+        crontab -l | { cat; echo "*/5 * * * * PYENV_VERSION=3.7.7; /var/mailcleaner/.pyenv/versions/3.7.7/bin/fail2ban.py cron-job >/dev/null 2>&1"; } | crontab -
+    fi
+
+    echo "Resyncing database..."
+    ${SRCDIR}/bin/resync_db.sh
+
+    if [[ `echo 'SELECT * FROM fail2ban_conf;' | mc_mysql -m mc_config | wc -c` -gt 1 ]]; then
+        echo "Fixing possibly broken tables..."
+        echo 'UPDATE fail2ban_conf SET chain="INPUT";' | mc_mysql -m mc_config
+        echo 'UPDATE fail2ban_ips SET jail="mc-webauth" WHERE jail LIKE "%mc-webauth%";' | mc_mysql -m mc_config
+        echo 'UPDATE fail2ban_ips SET jail="mc-ssh" WHERE jail LIKE "%mc-ssh%";' | mc_mysql -m mc_config
+        echo 'UPDATE fail2ban_ips SET jail="mc-exim" WHERE jail LIKE "%mc-exim%";' | mc_mysql -m mc_config
+    else
+        echo "Fixing missing tables..."
+        ROOT="`echo 'SELECT contact_email FROM system_conf;' | mc_mysql -m mc_config | tail -n 1`";
+        if [[ "$ROOT" == '' ]]; then 
+            ROOT="root@localhost"; 
+        fi;
+        echo "INSERT INTO fail2ban_conf(src_email,src_name,dest_email,chain) VALUES('$ROOT','MailCleaner - Fail2Ban','support@mailcleaner.net','INPUT');" | mc_mysql -m mc_config
+        echo "INSERT INTO fail2ban_jail(enabled,name,maxretry,findtime,bantime,port,filter,banaction,logpath,max_count,send_mail,send_mail_bl) VALUES(1,'mc-webauth',10,3600,86400,'80,443','mc-webauth-filter','mc-custom','/var/mailcleaner/log/apache/mc_auth.log',-1,0,1);" | mc_mysql -m mc_config
+        echo "INSERT INTO fail2ban_jail(enabled,name,maxretry,findtime,bantime,port,filter,banaction,logpath,max_count,send_mail,send_mail_bl) VALUES(1,'mc-ssh',3,3600,86400,'22','sshd','mc-custom','/var/log/auth.log',-1,0,1);" | mc_mysql -m mc_config
+        echo "INSERT INTO fail2ban_jail(enabled,name,maxretry,findtime,bantime,port,filter,banaction,logpath,max_count,send_mail,send_mail_bl) VALUES(1,'mc-exim',10,3600,86400,'25,465,587','mc-exim-filter','mc-custom','/var/mailcleaner/log/exim_stage1/rejectlog',-1,0,1);" | mc_mysql -m mc_config
+    fi 
+
+    echo "Restoring init file backup"
+    mv ${SRCDIR}/etc/init.d/fail2ban.bk ${SRCDIR}/etc/init.d/fail2ban
+
+    echo "3.7.7" > /root/.python-version
+    source /root/.bashrc
+    ${SRCDIR}/etc/init.d/fail2ban restart
+else
+    echo "Already found `which fail2ban.py`"
+fi
+
+set_version 2021 07 20 "Fix Python environment"


### PR DESCRIPTION
Remove declaration of Python environment from /root and add sourcing from tracked file.

For recently installed machines which have failed to install Fail2Ban because of the Pyenv path change, run the installation steps again.