### PR TITLE
Update version.def daily instead of once

### DIFF
--- a/libs/version.lib
+++ b/libs/version.lib
@@ -25,7 +25,6 @@ function set_version {
         exit 1
     fi
 
-    echo "$year.$month" > ${SRCDIR}/etc/mailcleaner/version.def
     version_id="${year}${month}${day}01"
     if [[ ! $(echo "select id from update_patch where id=$version_id" | ${SRCDIR}/bin/mc_mysql -s mc_config) ]]; then
         echo "insert into update_patch (id, date, time, status, description) values ( $version_id, '$year-$month-$day', '12:00:00', 'OK', '$year.$month $version_txt' )" | ${SRCDIR}/bin/mc_mysql -s mc_config

--- a/updater4mc.sh
+++ b/updater4mc.sh
@@ -131,6 +131,12 @@ do
     fi
 done
 . "${rpath}/updates/tolaunch.always" $1
+
+VERSION=$(echo "SELECT id FROM update_patch ORDER BY id DESC LIMIT 1" | /usr/mailcleaner/bin/mc_mysql -s mc_config | perl -e 'my ($id, $VERSION) = <STDIN>; $VERSION =~ s/(\d{4})(\d{2}).*/$1.$2/; print $VERSION')
+if grep -Pxq "\d\d\d\d\.\d\d" <<<$(echo $VERSION); then
+    echo $VERSION > ${SRCDIR}/etc/mailcleaner/version.def
+fi
+
 echo
 echo "$(date +%F_%T) End of Updater4MC:"
 echo ">> All updates done ! Follow forum announces or relaunch this script regularly."


### PR DESCRIPTION
Historically, $SRCDIR/etc/mailcleaner/version.def was tracked by Git. This often results in it being marked as changed, even though it should not be tracked anymore. As a result, it can get reverted to the initial value (2021.02) when git is reset.

Instead, this commit dumps the version to the file after updates complete every evening.

Because of this, the value is just a duplicate of the longer value from the database, so this is redundant. For the future, we should consider showing a commit version. This iwll be largely meaningless to users, but would provide a quick way of checking if the Git tree is actually up to date. Currently we are just reporting that the update succeeded at one point in time. If a machine has been rolled back, it would then have incorrect information. This would not be true if we showed the most recent commit hash.