### PR TITLE
Ignore merge commits

### DIFF
--- a/updater4mc.sh
+++ b/updater4mc.sh
@@ -92,7 +92,7 @@ if [ "$STATUS" != 'Already up-to-date.' ]; then
 fi
 
 cd "${SRCDIR}"
-SRCSTART=$(git log --decorate=no -n 1 | head -n 1 | cut -d' ' -f2)
+SRCSTART=$(git log --no-merges --decorate=no -n 1 | head -n 1 | cut -d' ' -f2)
 ${SRCDIR}/lib/updates/gitupdate.sh
 BRANCH=`git status | grep 'On branch' | sed -r 's/On branch //'`
 if [ "$BRANCH" != 'master' ]; then
@@ -113,7 +113,7 @@ if [ "$STATUS" != 'Already up-to-date.' ]; then
 		exit 1
 	fi
 fi
-SRCEND=$(git log --decorate=no -n 1 | head -n 1 | cut -d' ' -f2)
+SRCEND=$(git log --no-merges --decorate=no -n 1 | head -n 1 | cut -d' ' -f2)
 
 [ ! -d "${VARDIR}/spool/updater" ] && mkdir "${VARDIR}/spool/updater"
 


### PR DESCRIPTION
Otherwise many machines will have a version hash that is unique to it because the lasest commit is the merging of their local changes.

This should make it so that all machines with an up-to-date source tree all have a matching version code.