### PR TITLE
Patch MailScanner for longer Exim IDs

### DIFF
--- a/resources/ConfigDefs.pl_long_ids.patch
+++ b/resources/ConfigDefs.pl_long_ids.patch
@@ -1,0 +1,16 @@
+--- ConfigDefs.pl	2024-06-12 17:11:05.587164565 -0400
++++ ConfigDefs.pl.new	2024-06-12 17:10:49.022863933 -0400
+@@ -264,6 +264,7 @@
+ workuser			= incomingworkuser
+ workgroup			= incomingworkgroup
+ workperms			= incomingworkpermissions
++eximcommand			= EximCommand
+ 
+ 
+ #
+@@ -697,4 +698,5 @@
+ usespamcache            0       no      0       yes     1
+ spamcachedatabasefile
+ spamcachetimings
++EximCommand             /opt/exim4/bin/exim
+ ## end MailCleaner

--- a/resources/EximDiskStore.pm_long_ids.patch
+++ b/resources/EximDiskStore.pm_long_ids.patch
@@ -1,0 +1,79 @@
+--- EximDiskStore.pm	2017-05-09 07:42:44.000000000 -0400
++++ EximDiskStore.pm.new	2024-06-17 16:10:16.932813781 -0400
+@@ -216,9 +216,16 @@
+ # whether the spool is split or not.
+ sub OutQDir {
+   my $name = shift;
++  my $offset;
++
++  if (MailScanner::Config::Value('eximlongids') =~ /1/) {
++    $offset = -20;
++  } else {
++    $offset = -13;
++  }
+ 
+   if (MailScanner::Config::Value('spliteximspool')) {
+-    return '/' . substr($name,-13,1) . '/';
++    return '/' . substr($name,$offset,1) . '/';
+   } else {
+     return '/';
+   }
+@@ -441,9 +448,18 @@
+   # We have to strip the message-ID off the beginning of the file
+   # using sysread since that is what File::Copy uses and it doesn't
+   # play nicely with stdio operations such as $body->getline. The
+-  # magic number 19 is from the length of NNNNNN-NNNNNN-NN-D\n.
++  # magic number 19 or 26 is from the length of Exim ID with '-D'\n.
+   my $discard;
+-  sysread($body, $discard, 19);
++
++  my $offset;
++
++  if (MailScanner::Config::Value('eximlongids') =~ /1/) {
++    $offset = 26;
++  } else {
++    $offset = 19;
++  }
++
++  sysread($body, $discard, $offset);
+ 
+   copy($body, $handle);
+ 
+@@ -517,17 +533,25 @@
+   # We have to strip the message-ID off the beginning of the file
+   # using sysread since that is what File::Copy uses and it doesn't
+   # play nicely with stdio operations such as $body->getline. The
+-  # magic number 19 is from the length of NNNNNN-NNNNNN-NN-D\n.
++  # magic number 19 or 26 is the length of the Exim ID with '-D'\n.
+   my $from_h = \do { local *FH1 };
+   open($from_h, "< $dhandle");
+   binmode $from_h or die "($!,$^E)";
+ 
+-  sysseek($from_h, 19, 0);
++  my $offset;
++
++  if (MailScanner::Config::Value('eximlongids') =~ /1/) {
++    $offset = 26;
++  } else {
++    $offset = 19;
++  }
++
++  sysseek($from_h, $offset, 0);
+ 
+   my $size;
+   my $buf = "";
+   my $lasteol = ' ';
+-  my $dlength = -s $dhandle; # Catch case where -D file is 0 (ie 19) bytes
++  my $dlength = -s $dhandle; # Catch case where -D file is 0 (ie 19 or 26) bytes
+   $size = $dlength;
+   $size = 1024 if ($size < 512);
+   $size = 1024*1024*2 if $size > 1024*1024*2;
+@@ -546,7 +570,7 @@
+ 
+   # Need to ensure the end of the file is and new-line character,
+   # unless it's a 0 length file.
+-  if ($lasteol !~ /[\n\r]/s && $dlength>19) {
++  if ($lasteol !~ /[\n\r]/s && $dlength>$offset) {
+     $lasteol = "\n";
+     syswrite($to_h, $lasteol);
+   }

--- a/resources/MailScanner_long_ids.patch
+++ b/resources/MailScanner_long_ids.patch
@@ -1,0 +1,39 @@
+--- MailScanner	2024-06-17 16:36:51.033275535 -0400
++++ MailScanner.new	2024-06-17 17:14:52.554514979 -0400
+@@ -377,6 +377,36 @@
+ $_=MailScanner::Config::QuickPeek($ConfFile, 'mta');
+ $_='sendmail' if $WantLintOnly || $WantLintLiteOnly || $WantRuleCheck;
+ if (/exim/i) {
++  # Check for version >= 4.97
++  my $eximcommand = MailScanner::Config::QuickPeek($ConfFile, 'eximcommand');
++  if ($eximcommand eq "") {
++    # try to find exim
++    eval {
++      $eximcommand = `which exim`;
++    };
++    if (defined($@) && $@ ne '') {
++      print STDERR "Exim binary not found. Please supply the full path to Exim Command in MailScanner.conf";
++      exit 1;
++    }
++  }
++  # Get exim version
++  my @out;
++  my $ver;
++  eval {
++    @out = `$eximcommand -bV`;
++    my @line = split(/ /, $out[0]);
++    $ver = $line[2];
++    $ver =~ /\d+\.\d+/;
++  };
++  if ($@) {
++    print STDERR "Unable to obtain version of Exim. Please check the path to Exim Command in MailScanner.conf";
++    exit 1;
++  }
++  if ($ver >= 4.97) {
++    MailScanner::Config::SetValue('eximlongids',1);
++  } else {
++    MailScanner::Config::SetValue('eximlongids',0);
++  }
+   $MTAmod = 'Exim.pm';
+   $MTADSmod = 'EximDiskStore.pm';
+ } elsif(/zmailer/i) {

--- a/updates/90_MailScanner_long_ids.update
+++ b/updates/90_MailScanner_long_ids.update
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+export PATH="/usr/mailcleaner/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+# Patch MailScanner to function with new, longer, exim IDs
+
+cp -f /root/Updater4MC/resources/MailScanner_long_ids.patch /opt/MailScanner/bin/
+cp -f /root/Updater4MC/resources/ConfigDefs.pl_long_ids.patch /opt/MailScanner/lib/MailScanner/
+cp -f /root/Updater4MC/resources/EximDiskStore.pm_long_ids.patch /opt/MailScanner/lib/MailScanner/
+
+cd /opt/MailScanner/bin
+
+cp MailScanner MailScanner_long_ids
+patch -i MailScanner_long_ids.patch MailScanner
+rm -f MailScanner_long_ids.patch 
+
+cd -
+cd /opt/MailScanner/lib/MailScanner/
+
+cp ConfigDefs.pl ConfigDefs.pl_long_ids
+patch -i ConfigDefs.pl_long_ids.patch ConfigDefs.pl
+rm -f ConfigDefs.pl_long_ids.patch
+
+cp EximDiskStore.pm EximDiskStore.pm_long_ids
+patch -i EximDiskStore.pm_long_ids.patch EximDiskStore.pm
+rm -f EximDiskStore.pm_long_ids.patch
+
+cd -
+
+set_version 2024 06 17 "MailScanner long Exim IDs patch"


### PR DESCRIPTION
Prevents tail end of ID from being left behind after content rewriting